### PR TITLE
WINDUP-1172 - upgraded wildfly-maven plugin to 1.1.0.Beta1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <version.nexus.index>5</version.nexus.index>
         <version.keycloak>2.1.0.Final</version.keycloak>
         <version.wildfly>10.1.0.Final</version.wildfly>
-        <version.wildfly.maven.plugin>1.1.0.Alpha11</version.wildfly.maven.plugin>
+        <version.wildfly.maven.plugin>1.1.0.Beta1</version.wildfly.maven.plugin>
 
         <windup.scm.connection>scm:git:https://github.com/windup/windup-web-distribution.git</windup.scm.connection>
         <windup.developer.connection>scm:git:git@github.com:windup/windup-web-distribution.git</windup.developer.connection>


### PR DESCRIPTION
updated to fixed wildfly-maven-plugin version and the output looks like the following:

```
[INFO] --- wildfly-maven-plugin:1.1.0.Beta1:start (start-wildfly) @ windup-web-distribution ---
Nov 30, 2016 11:20:40 AM org.xnio.Xnio <clinit>
INFO: XNIO version 3.3.1.Final
Nov 30, 2016 11:20:40 AM org.xnio.nio.NioXnio <clinit>
INFO: XNIO NIO Implementation Version 3.3.1.Final
Nov 30, 2016 11:20:40 AM org.jboss.remoting3.EndpointImpl <clinit>
INFO: JBoss Remoting version 4.0.9.Final
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 10.374 s
[INFO] Finished at: 2016-11-30T11:20:40+01:00
[INFO] Final Memory: 30M/369M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.wildfly.plugins:wildfly-maven-plugin:1.1.0.Beta1:start (start-wildfly) on project windup-web-distribution: The server failed to start: STANDALONE server is already running? -> [Help 1]
```
