### PR TITLE
WINDUP-1460 Configure https listener

### DIFF
--- a/src/main/resources/openshift/app/configuration/eap.cli.original
+++ b/src/main/resources/openshift/app/configuration/eap.cli.original
@@ -19,5 +19,9 @@ jms-topic add --topic-address=executorCancellation --entries=topics/executorCanc
 /subsystem=undertow/configuration=handler/file=windup-web-redirect:write-attribute(name=path,value=${jboss.home.dir}/windup-web-redirect)
 /subsystem=undertow/server=default-server/host=default-host/location=\//:write-attribute(name=handler,value=windup-web-redirect)
 
+/core-service=management/security-realm=HTTPSRealm/:add
+/core-service=management/security-realm=HTTPSRealm/server-identity=ssl:add(keystore-path=/etc/eap-secret-volume/keystore.jks,keystore-password=HTTPS_PASSWORD,alias=HTTPS_NAME)
+/subsystem=undertow/server=default-server/https-listener=https:add(socket-binding=https, security-realm=HTTPSRealm)
+/subsystem=undertow/server=default-server/https-listener=https:write-attribute(name=max-post-size, value=943718400)
 
 stop-embedded-server

--- a/src/main/resources/openshift/app/configuration/eap.cli.original
+++ b/src/main/resources/openshift/app/configuration/eap.cli.original
@@ -19,9 +19,6 @@ jms-topic add --topic-address=executorCancellation --entries=topics/executorCanc
 /subsystem=undertow/configuration=handler/file=windup-web-redirect:write-attribute(name=path,value=${jboss.home.dir}/windup-web-redirect)
 /subsystem=undertow/server=default-server/host=default-host/location=\//:write-attribute(name=handler,value=windup-web-redirect)
 
-/core-service=management/security-realm=HTTPSRealm/:add
-/core-service=management/security-realm=HTTPSRealm/server-identity=ssl:add(keystore-path=/etc/eap-secret-volume/keystore.jks,keystore-password=HTTPS_PASSWORD,alias=HTTPS_NAME)
-/subsystem=undertow/server=default-server/https-listener=https:add(socket-binding=https, security-realm=HTTPSRealm)
 /subsystem=undertow/server=default-server/https-listener=https:write-attribute(name=max-post-size, value=943718400)
 
 stop-embedded-server

--- a/src/main/resources/openshift/deploy.sh
+++ b/src/main/resources/openshift/deploy.sh
@@ -85,7 +85,10 @@ sed -i -e "s#HTTPS_PASSWORD#$HTTPS_PASSWORD#g" app/configuration/eap.cli
 
 echo "  -> Process RHAMT template"
 # Template adapted from https://github.com/jboss-openshift/application-templates/blob/master/eap/eap70-postgresql-persistent-s2i.json
-oc process -f templates/rhamt-template.json -p POSTGRESQL_MAX_CONNECTIONS=200 | oc create -n ${OCP_PROJECT} -f -
+oc process -f templates/rhamt-template.json \
+    -p POSTGRESQL_MAX_CONNECTIONS=200 \
+    -p HTTPS_NAME=${HTTPS_NAME} \
+    -p HTTPS_PASSWORD=${HTTPS_PASSWORD} | oc create -n ${OCP_PROJECT} -f -
 
 echo
 echo "Build images"

--- a/src/main/resources/openshift/templates/rhamt-template.json
+++ b/src/main/resources/openshift/templates/rhamt-template.json
@@ -405,7 +405,8 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "description": "The web server's http port."
+                    "description": "The web server's http port.",
+                    "service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]"
                 }
             }
         },
@@ -429,7 +430,8 @@
                     "application": "${APPLICATION_NAME}"
                 },
                 "annotations": {
-                    "description": "The web server's https port."
+                    "description": "The web server's https port.",
+                    "service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]"
                 }
             }
         },

--- a/src/main/resources/openshift/templates/sso70-postgresql-persistent.json
+++ b/src/main/resources/openshift/templates/sso70-postgresql-persistent.json
@@ -247,6 +247,13 @@
             "name": "SSO_TRUSTSTORE_SECRET",
             "value": "sso-app-secret",
             "required": false
+        },
+        {
+            "displayName": "Openshift Project Name",
+            "description": "The name of the project containing this application",
+            "name": "OCP_PROJECT",
+            "value": "",
+            "required": true
         }
     ],
     "objects": [
@@ -390,7 +397,7 @@
                             ],
                             "from": {
                                 "kind": "ImageStreamTag",
-                                "namespace": "rhamt",
+                                "namespace": "${OCP_PROJECT}",
                                 "name": "rhamt-sso:latest"
                             }
                         }


### PR DESCRIPTION
- Fixed `sso-builder` to use `OCP_PROJECT` variable
- configured https listener working
- Increased https listener post size
- Made `${keycloak.serverUrl}` in `[index.html.ftl](https://github.com/windup/windup-web/blob/master/ui/src/main/webapp/src/index.html.ftl#L6)` pointing to `secure-sso` URL using `https` (to avoid blocked mixed content for `keycloak.js` file)
- Made service group with `rhamt` and its postgresql
