### PR TITLE
Fix sso-builder

### DIFF
--- a/src/main/resources/openshift/deploy.sh
+++ b/src/main/resources/openshift/deploy.sh
@@ -53,7 +53,7 @@ oc create -n ${OCP_PROJECT} -f templates/sso-app-secret.json
 sleep 1
 
 echo "  -> Build 'sso-builder' image"
-oc process -f templates/rhamt-sso-image.json | oc create -n rhamt -f -
+oc process -f templates/rhamt-sso-image.json | oc create -n ${OCP_PROJECT} -f -
 
 oc start-build --wait --from-dir=sso-builder rhamt-sso
 
@@ -66,7 +66,8 @@ oc process -f templates/sso70-postgresql-persistent.json \
     -p SSO_SERVICE_PASSWORD=admin \
     -p SSO_REALM=rhamt \
     -p HTTPS_NAME=jboss \
-    -p HTTPS_PASSWORD=mykeystorepass | oc create -n ${OCP_PROJECT} -f -
+    -p HTTPS_PASSWORD=mykeystorepass \
+    -p OCP_PROJECT=${OCP_PROJECT} | oc create -n ${OCP_PROJECT} -f -
 
 echo "    -> Waiting on SSO startup (90 seconds)..."
 sleep 90

--- a/src/main/resources/openshift/templates/rhamt-template.json
+++ b/src/main/resources/openshift/templates/rhamt-template.json
@@ -402,10 +402,12 @@
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
-                    "application": "${APPLICATION_NAME}"
+                    "application": "${APPLICATION_NAME}",
+                    "app": "${APPLICATION_NAME}-http"
                 },
                 "annotations": {
-                    "description": "The web server's http port."
+                    "description": "The web server's http port.",
+                    "service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]"
                 }
             }
         },
@@ -426,10 +428,12 @@
             "metadata": {
                 "name": "secure-${APPLICATION_NAME}",
                 "labels": {
-                    "application": "${APPLICATION_NAME}"
+                    "application": "${APPLICATION_NAME}",
+                    "app": "${APPLICATION_NAME}-https"
                 },
                 "annotations": {
-                    "description": "The web server's https port."
+                    "description": "The web server's https port.",
+                    "service.alpha.openshift.io/dependencies": "[{\"name\": \"${APPLICATION_NAME}-postgresql\", \"kind\": \"Service\"}]"
                 }
             }
         },

--- a/src/main/resources/openshift/templates/sso70-postgresql-persistent.json
+++ b/src/main/resources/openshift/templates/sso70-postgresql-persistent.json
@@ -247,6 +247,13 @@
             "name": "SSO_TRUSTSTORE_SECRET",
             "value": "sso-app-secret",
             "required": false
+        },
+        {
+            "displayName": "Openshift Project Name",
+            "description": "The name of the project containing this application",
+            "name": "OCP_PROJECT",
+            "value": "",
+            "required": true
         }
     ],
     "objects": [
@@ -267,7 +274,8 @@
             "metadata": {
                 "name": "${APPLICATION_NAME}",
                 "labels": {
-                    "application": "${APPLICATION_NAME}"
+                    "application": "${APPLICATION_NAME}",
+                    "app": "${APPLICATION_NAME}-http"
                 },
                 "annotations": {
                     "description": "The web server's http port.",
@@ -292,7 +300,8 @@
             "metadata": {
                 "name": "secure-${APPLICATION_NAME}",
                 "labels": {
-                    "application": "${APPLICATION_NAME}"
+                    "application": "${APPLICATION_NAME}",
+                    "app": "${APPLICATION_NAME}-https"
                 },
                 "annotations": {
                     "description": "The web server's https port.",
@@ -390,7 +399,7 @@
                             ],
                             "from": {
                                 "kind": "ImageStreamTag",
-                                "namespace": "rhamt",
+                                "namespace": "${OCP_PROJECT}",
                                 "name": "rhamt-sso:latest"
                             }
                         }


### PR DESCRIPTION
- fixed sso-builder to use OCP_PROJECT variable
- made service group with rhamt and its postgresql using `service.alpha.openshift.io/dependencies` annotation
- added labels `app` to all the services in templates to have labels in OCP UI beside services' URL