### PR TITLE
Several improvements for the OCP deployment

### DIFF
--- a/src/main/resources/openshift/app/configuration/eap.cli
+++ b/src/main/resources/openshift/app/configuration/eap.cli
@@ -7,7 +7,7 @@ jms-topic add --topic-address=executorCancellation --entries=topics/executorCanc
 
 /subsystem=keycloak:remove
 /subsystem=keycloak:add
-/system-property=keycloak.server.url:add(value="KEYCLOAK_URL")
+
 /system-property=keycloak.realm.public.key:add(value="MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAhlI4WQ3tbIFE71M0HAO3TfvJFxH0P16wdOSzc/Fr9l8/tOn8cN5sgkGpnyEWcawgv2z4nouUkpV92/vo9fadKr3KVUMVaE3EaR3BmsC0Ct6TY7mYD+sz/yGoSWqwmGYocEJRIXAuMCX3jCu6CKMSV+1qjpcyYqzRaVWTB/EV76Sx+CSh9rEMLl8mE6owxNWQck03KgvWCA70l/LAu1M1bWy1aozoUKiTryX0nTxbHbj4qg3vvHC6igYndJ4zLr30QlCVn1iQ1jXC1MQUJ+Mwc8yZlkhaoAfDS1iM9I8NUcpcQAIn2baD8/aBrS1F9woYYRvo0vFH5N0+Rw4xjgSDlQIDAQAB")
 
 /subsystem=keycloak/secure-deployment=api.war:add(realm=rhamt, realm-public-key="${keycloak.realm.public.key}", auth-server-url="${keycloak.server.url}", ssl-required="EXTERNAL", resource=rhamt-web, public-client=true)

--- a/src/main/resources/openshift/builder/Dockerfile
+++ b/src/main/resources/openshift/builder/Dockerfile
@@ -21,7 +21,7 @@ RUN sed -i -e 's#-javaagent:$JBOSS_HOME/jolokia.jar=port=8778,protocol=https,caC
 RUN echo "export LANG=C.UTF-8" >> /opt/eap/bin/openshift-launch.sh
 
 # Add updated "standalone.sh"
-RUN echo 'exec $JBOSS_HOME/bin/standalone.sh -c standalone-openshift.xml -bmanagement 127.0.0.1 $JBOSS_HA_ARGS ${JBOSS_MESSAGING_ARGS}' >> /opt/eap/bin/openshift-launch.sh
+RUN echo 'exec $JBOSS_HOME/bin/standalone.sh -c standalone-openshift.xml -P ${JBOSS_HOME}/standalone/configuration/eap.properties -bmanagement 127.0.0.1 $JBOSS_HA_ARGS ${JBOSS_MESSAGING_ARGS}' >> /opt/eap/bin/openshift-launch.sh
 
 USER 0
 RUN sed -i 's/cp -v /cp -av /' -- /usr/local/s2i/assemble

--- a/src/main/resources/openshift/builder/Dockerfile
+++ b/src/main/resources/openshift/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM jboss-eap-7/eap70-openshift:1.4
+FROM jboss-eap-7/eap70-openshift:latest
 
 ADD windup-web-redirect /opt/eap/windup-web-redirect
 

--- a/src/main/resources/openshift/builder/inject.sh
+++ b/src/main/resources/openshift/builder/inject.sh
@@ -2,10 +2,5 @@
 
 mkdir -p ${JBOSS_HOME}/standalone/log
 
-
-echo ">>> CLI" >> ${JBOSS_HOME}/standalone/log/inj.log
-
 # Run our CLI script
 ${JBOSS_HOME}/bin/jboss-cli.sh --file=${JBOSS_HOME}/standalone/configuration/eap.cli >>${JBOSS_HOME}/standalone/log/inj.log 2>&1
-
-echo "<<< CLI" >> ${JBOSS_HOME}/standalone/log/inj.log

--- a/src/main/resources/openshift/deploy.sh
+++ b/src/main/resources/openshift/deploy.sh
@@ -3,32 +3,30 @@
 set -e
 
 OCP_PROJECT=rhamt
+
 DB_DATABASE=WindupServicesDS
 DB_USERNAME=postgresuser
 DB_PASSWORD=postgrespassword
-
 APP=rhamt-web-console
 APP_DIR=app
 SERVICES_WAR=${APP_DIR}/api.war
 UI_WAR=${APP_DIR}/rhamt-web.war
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd $SCRIPT_DIR
+cd ${SCRIPT_DIR}
 
 # Copy root war configuration
 cp -R ../windup-web-redirect builder/
 
 # Copy deployments
-cp ../standalone/deployments/api.war $SERVICES_WAR
-cp ../standalone/deployments/rhamt-web.war $UI_WAR
+cp ../standalone/deployments/api.war ${SERVICES_WAR}
+cp ../standalone/deployments/rhamt-web.war ${UI_WAR}
 
 # Copy SSO Themes
 rm -rf sso-builder/themes
 mkdir -p sso-builder/themes/
 cp -R ../themes/rhamt sso-builder/themes/
 cp sso-builder/themes/rhamt/login/login_required.theme.properties sso-builder/themes/rhamt/login/theme.properties
-
-
 
 # Checks if the "api.war" file has been added properly
 ls -al ${SERVICES_WAR}
@@ -52,7 +50,6 @@ oc project ${OCP_PROJECT}  2>&1 > /dev/null
 
 echo
 echo "Project setup"
-
 # Templates taken from https://github.com/jboss-openshift/application-templates/tree/master/secrets
 echo "  -> Populate EAP and SSO secrets"
 oc create -n ${OCP_PROJECT} -f templates/eap-app-secret.json

--- a/src/main/resources/openshift/deploy.sh
+++ b/src/main/resources/openshift/deploy.sh
@@ -117,4 +117,22 @@ oc start-build --wait --from-dir=builder eap-builder
 echo "  -> Build '${APP}' application image"
 oc start-build --wait --from-dir=${APP_DIR} ${APP}
 
-echo "Build and upload complete!"
+echo "  -> Deploy RHAMT Web Console ..."
+N=0
+until [ ${N} -ge 50 ]
+do
+  IS_RUNNING=$(oc get pods | grep rhamt-web-console | grep -v build | grep Running| wc -l)
+  if [ ${IS_RUNNING} == "1" ]
+  then
+    break
+  else
+    N=$[${N}+1]
+    sleep 5
+  fi
+done
+
+CONSOLE_URL="http://$(oc get route --no-headers -o=custom-columns=HOST:.spec.host rhamt-web-console)/"
+
+echo "Upload, build and deployment successful!"
+echo
+echo "Open ${CONSOLE_URL} to start using the RHAMT Web Console on OpenShift (user='rhamt',password='password')"

--- a/src/main/resources/openshift/deploy.sh
+++ b/src/main/resources/openshift/deploy.sh
@@ -115,6 +115,6 @@ echo "  -> Build 'eap-builder' image"
 oc start-build --wait --from-dir=builder eap-builder
 
 echo "  -> Build '${APP}' application image"
-oc start-build --wait --from-dir=${APP_DIR} ${APP} 2>/dev/null > /dev/null
+oc start-build --wait --from-dir=${APP_DIR} ${APP}
 
 echo "Build and upload complete!"

--- a/src/main/resources/openshift/deploy.sh
+++ b/src/main/resources/openshift/deploy.sh
@@ -95,15 +95,9 @@ oc process -f templates/sso70-postgresql-persistent.json \
     -p OCP_PROJECT=${OCP_PROJECT} | oc create -n ${OCP_PROJECT} -f -
 sleep 1
 
-echo "    -> Waiting on SSO startup (90 seconds)..."
-sleep 90
-
-SSO_HOSTNAME=`oc get route --no-headers -o=custom-columns=HOST:.spec.host sso`
-SSO_URL="http://$SSO_HOSTNAME/auth"
-
-echo "  -> SSO URL: $SSO_URL"
-cp app/configuration/eap.cli.original app/configuration/eap.cli
-sed -i -e "s#KEYCLOAK_URL#$SSO_URL#g" app/configuration/eap.cli
+SSO_HOSTNAME="$(oc get route --no-headers -o=custom-columns=HOST:.spec.host sso)"
+echo "keycloak.server.url=http://${SSO_HOSTNAME}/auth" > app/configuration/eap.properties
+#echo "     SSO URL: ${SSO_HOSTNAME}"
 
 echo "  -> Process RHAMT template"
 # Template adapted from https://github.com/jboss-openshift/application-templates/blob/master/eap/eap70-postgresql-persistent-s2i.json

--- a/src/main/resources/openshift/deploy.sh
+++ b/src/main/resources/openshift/deploy.sh
@@ -41,12 +41,12 @@ echo "Openshift project"
 echo "  -> Create Openshift project (${OCP_PROJECT})"
 oc new-project ${OCP_PROJECT} > /dev/null
 sleep 1
-
-oc policy add-role-to-user view system:serviceaccount:$(oc project -q):eap-service-account -n $(oc project -q)
-oc policy add-role-to-user view system:serviceaccount:$(oc project -q):sso-service-account -n $(oc project -q)
-
 echo "  -> Switch to project"
 oc project ${OCP_PROJECT} > /dev/null
+sleep 1
+echo "  -> Register service accounts"
+oc policy add-role-to-user view system:serviceaccount:${OCP_PROJECT}:eap-service-account -n ${OCP_PROJECT}
+oc policy add-role-to-user view system:serviceaccount:${OCP_PROJECT}:sso-service-account -n ${OCP_PROJECT}
 sleep 1
 
 echo

--- a/src/main/resources/openshift/deploy.sh
+++ b/src/main/resources/openshift/deploy.sh
@@ -79,7 +79,7 @@ oc start-build --wait --from-dir=sso-builder rhamt-sso
 sleep 1
 
 echo "  -> Process SSO template"
-# Template adapted from https://github.com/jboss-openshift/application-templates/blob/master/sso/sso71-postgresql-persistent.json
+# Template adapted from https://github.com/jboss-openshift/application-templates/blob/master/sso/sso70-postgresql-persistent.json
 oc process -f templates/sso70-postgresql-persistent.json \
     -p SSO_ADMIN_USERNAME=admin \
     -p SSO_ADMIN_PASSWORD=admin \

--- a/src/main/resources/openshift/deploy.sh
+++ b/src/main/resources/openshift/deploy.sh
@@ -39,14 +39,15 @@ rc=$?; if [[ $rc != 0 ]]; then echo "Missing deployment. Please build and copy r
 echo
 echo "Openshift project"
 echo "  -> Create Openshift project (${OCP_PROJECT})"
-oc new-project ${OCP_PROJECT} 2>/dev/null > /dev/null
+oc new-project ${OCP_PROJECT} > /dev/null
 sleep 1
 
 oc policy add-role-to-user view system:serviceaccount:$(oc project -q):eap-service-account -n $(oc project -q)
 oc policy add-role-to-user view system:serviceaccount:$(oc project -q):sso-service-account -n $(oc project -q)
 
 echo "  -> Switch to project"
-oc project ${OCP_PROJECT}  2>&1 > /dev/null
+oc project ${OCP_PROJECT} > /dev/null
+sleep 1
 
 echo
 echo "Project setup"
@@ -59,8 +60,9 @@ sleep 1
 
 echo "  -> Build 'sso-builder' image"
 oc process -f templates/rhamt-sso-image.json | oc create -n ${OCP_PROJECT} -f -
-
+sleep 1
 oc start-build --wait --from-dir=sso-builder rhamt-sso
+sleep 1
 
 echo "  -> Process SSO template"
 # Template adapted from https://github.com/jboss-openshift/application-templates/blob/master/sso/sso71-postgresql-persistent.json
@@ -77,6 +79,7 @@ oc process -f templates/sso70-postgresql-persistent.json \
     -p DB_USERNAME=${DB_USERNAME} \
     -p DB_PASSWORD=${DB_PASSWORD} \
     -p OCP_PROJECT=${OCP_PROJECT} | oc create -n ${OCP_PROJECT} -f -
+sleep 1
 
 echo "    -> Waiting on SSO startup (90 seconds)..."
 sleep 90

--- a/src/main/resources/openshift/deploy.sh
+++ b/src/main/resources/openshift/deploy.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 OCP_PROJECT=rhamt
 DB_DATABASE=WindupServicesDS
 DB_USERNAME=postgresuser

--- a/src/main/resources/openshift/deploy.sh
+++ b/src/main/resources/openshift/deploy.sh
@@ -48,6 +48,20 @@ echo "  -> Register service accounts"
 oc policy add-role-to-user view system:serviceaccount:${OCP_PROJECT}:eap-service-account -n ${OCP_PROJECT}
 oc policy add-role-to-user view system:serviceaccount:${OCP_PROJECT}:sso-service-account -n ${OCP_PROJECT}
 sleep 1
+echo "  -> Verify ImageStreams"
+sleep 1
+M=0
+until [ ${M} -ge 50 ]
+do
+  EAP_IMG=$(oc describe is jboss-eap70-openshift -n openshift|grep latest|grep tagged|wc -l)
+  SSO_IMG=$(oc describe is redhat-sso70-openshift -n openshift |grep latest|grep tagged|wc -l)
+  if [ ${EAP_IMG} == "1" ]  && [ ${SSO_IMG} == "1" ]; then
+    break
+  else
+    M=$[${M}+1]
+    sleep 5
+  fi
+done
 
 echo
 echo "Project setup"

--- a/src/main/resources/openshift/sso-builder/Dockerfile
+++ b/src/main/resources/openshift/sso-builder/Dockerfile
@@ -1,9 +1,7 @@
-FROM redhat-sso-7/sso70-openshift:1.3
+FROM redhat-sso-7/sso70-openshift:latest
 
 ADD import-realm.json /opt/eap/standalone/configuration/import-realm.json
 ADD themes/rhamt /opt/eap/themes/rhamt/
 
 RUN /opt/eap/bin/add-user-keycloak.sh --realm rhamt --user rhamt --password password --roles user
 RUN /opt/eap/bin/add-user-keycloak.sh --realm master --user admin --password password
-
-


### PR DESCRIPTION
I made and tested several improvements for the OCP distribution:
- update all used images to ":latest"
- add a wait mechanism to let some time for a "fresh" OCP installation to download the latest image streams
- add a proper Java system properties file (keycloak URL)
- wait mechanism at the end till the application is deployed
- display the rhamt-console URL at the end 
- various small consolidations and updates