### PR TITLE
WINDUP-1545 Log filtering

### DIFF
--- a/src/main/resources/openshift/app/configuration/eap.cli
+++ b/src/main/resources/openshift/app/configuration/eap.cli
@@ -19,5 +19,27 @@ jms-topic add --topic-address=executorCancellation --entries=topics/executorCanc
 /subsystem=undertow/configuration=handler/file=windup-web-redirect:write-attribute(name=path,value=${jboss.home.dir}/windup-web-redirect)
 /subsystem=undertow/server=default-server/host=default-host/location=\//:write-attribute(name=handler,value=windup-web-redirect)
 
+# Logging
+/subsystem=logging/logger=org.jboss.windup:add(level=INFO, use-parent-handlers=false, handlers=[])
+/subsystem=logging/logger=org.jboss.windup.web:add(level=INFO, use-parent-handlers=false, handlers=[CONSOLE])
+/subsystem=logging/logger=org.jboss.windup.web.services.WindupWebProgressMonitor:add(level=INFO, use-parent-handlers=false, handlers=[])
+
+## Reduce the Furnace loading warnings.
+/subsystem=logging/logger=org.jboss.forge.furnace.container.simple.impl.SimpleServiceRegistry/:add(level=SEVERE)
+## Validator complains about "ClassX declared a normal scope but does not implement javax.enterprise.inject.spi.PassivationCapable. ..."
+/subsystem=logging/logger=org.jboss.weld.Validator/:add(level=ERROR)
+## DEBUG Configuring component class: ...
+/subsystem=logging/logger=org.jboss.as.ee/:add(level=INFO)
+## MSC000004: Failure during stop of service jboss.deployment.unit."api.war".WeldStartService: org.jboss.forge.furnace.exception.ContainerException:
+## Could not get services of type [interface org.jboss.windup.web.addons.websupport.WindupWebServiceFactory] from addon [org.jboss.windup.web.addons:windup-web-support,4.0.0-SNAPSHOT +STARTED]
+/subsystem=logging/logger=org.jboss.msc.service.fail/:add(level=ERROR)
+## HHH000431: Unable to determine H2 database version, certain features may not work
+/subsystem=logging/logger=org.hibernate.dialect.H2Dialect/:add(level=ERROR)
+
+## Remove spurious Titan warnings
+/subsystem=logging/logger=com.thinkaurelius.titan.diskstorage.berkeleyje/:add(level=ERROR)
+
+/subsystem=logging/logger=org.jboss.weld.Bootstrap/:add(level=WARN)
+/subsystem=logging/logger=org.jboss.weld.Event/:add(level=WARN)
 
 stop-embedded-server


### PR DESCRIPTION
Changes:
- applied [log configurations](https://github.com/windup/windup-web-distribution/blob/master/src/main/cli/setup-eap.cli#L12) from ZIP installation CLI script
- added `org.jboss.weld.[Bootstrap,Event]` handler at `WARN` level

To start EAP,create a project and run an analysis the log:
- was more than 700KB before
- is about 100KB now
