### PR TITLE
Fixup non-integer ulimit output on Mac OS X v10.11

### DIFF
--- a/src/main/resources/run_rhamt.sh
+++ b/src/main/resources/run_rhamt.sh
@@ -7,6 +7,11 @@ WE_NEED=1024
 MAX_HARD=$(ulimit -H -n);
 MAX_SOFT=$(ulimit -S -n);
 
+# ulimit command produces non-integer output 'unlimited' on Mac OS X v10.11
+if [ $MAX_HARD == "unlimited" ] ; then
+    let "MAX_HARD = $WE_NEED + 1"
+fi
+
 if [ $MAX_SOFT -lt $WE_NEED ] ; then 
 
   if [ $MAX_HARD -lt $WE_NEED ] ; then 


### PR DESCRIPTION
The startup script fails on my Mac OS X v10.11.6 because `ulimit -H -n` returns `unlimited` rather than an integer value, as the script expects. 