### PR TITLE
WINDUP-2113 Upgrade wildfly-maven-plugin to 1.2.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <version.wildfly>11.0.0.Final</version.wildfly>
         <wildfly.directory>wildfly-${version.wildfly}</wildfly.directory>
 
-        <version.wildfly.maven.plugin>1.2.1.Final</version.wildfly.maven.plugin>
+        <version.wildfly.maven.plugin>1.2.2.Final</version.wildfly.maven.plugin>
 
         <windup.scm.connection>scm:git:https://github.com/windup/windup-web-distribution.git</windup.scm.connection>
         <windup.developer.connection>scm:git:git@github.com:windup/windup-web-distribution.git</windup.developer.connection>


### PR DESCRIPTION
It works with:
* Apache Maven 3.5.2 (Red Hat 3.5.2-5)
* Java version: 1.8.0_172

Related to https://github.com/windup/windup-web/pull/585 and due to https://issues.jboss.org/browse/WFMP-94