### PR TITLE
WINDUP-2101 Increase the startup timeout for wildfly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -341,6 +341,7 @@
                                 <script>src/main/cli/setup-eap.cli</script>
                                 <script>src/main/cli/adding-redirect.cli</script>
                             </scripts>
+                            <startupTimeout>300</startupTimeout>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
Increased the startup timeout for wildfly during the build since it happens frequently that we reach the 60 seconds timeout due to some lack of resources in the building host.