### PR TITLE
WINDUP-2273 Update README to reference windup-local-build-scripts

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -12,7 +12,9 @@ To build this project, type:
 
 This creates a `windup-web-distribution-<VERSION>.zip` file in the `windup-web-distribution/target/` directory.
 
-The windup-web-distribution build requires artifacts built from windup-web and windup-keycloak-tool. The sequence of commands https://github.com/d-s/scripts-windup/blob/9a0184c9af6d7fc3a33611e071cb3f2620cb7683/windup-web-dist-build.sh[here] should work.
+The windup-web-distribution build requires artifacts built from windup-web and windup-keycloak-tool.
+
+A script to build this project and its dependencies (above) can be found here: https://github.com/windup/windup-local-build-scripts[windup-local-build-scripts].
 
 == Additional Resources
 


### PR DESCRIPTION
Added a link to the windup-local-build-scripts github repository to make it easy to build the windup-web-distribution project and its dependencies. 