### PR TITLE
Windup 2507 migrate distribution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,11 @@
     <packaging>pom</packaging>
 
     <properties>
-        <version.keycloak>4.8.3.Final</version.keycloak>
+        <version.keycloak>8.0.1</version.keycloak>
 
         <wildfly.groupId>org.wildfly</wildfly.groupId>
         <wildfly.artifactId>wildfly-dist</wildfly.artifactId>
-        <version.wildfly>15.0.1.Final</version.wildfly>
+        <version.wildfly>18.0.1.Final</version.wildfly>
         <wildfly.directory>wildfly-${version.wildfly}</wildfly.directory>
 
         <version.wildfly.maven.plugin>2.0.1.Final</version.wildfly.maven.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
         <version.wildfly>18.0.1.Final</version.wildfly>
         <wildfly.directory>wildfly-${version.wildfly}</wildfly.directory>
 
-        <version.wildfly.maven.plugin>2.0.1.Final</version.wildfly.maven.plugin>
+        <version.wildfly.maven.plugin>2.0.2.Final</version.wildfly.maven.plugin>
 
         <windup.scm.connection>scm:git:https://github.com/windup/windup-web-distribution.git</windup.scm.connection>
         <windup.developer.connection>scm:git:git@github.com:windup/windup-web-distribution.git</windup.developer.connection>
@@ -342,12 +342,16 @@
                             <goal>execute-commands</goal>
                         </goals>
                         <configuration>
+                            <fork>true</fork>
                             <jbossHome>${project.build.directory}/${wildfly.directory}</jbossHome>
                             <serverConfig>standalone-full.xml</serverConfig>
                             <stdout>${project.build.directory}/jboss.stdout</stdout>
                             <systemProperties>
                                 <windup.data.dir>${jboss.server.data.dir}/h2/windup-web</windup.data.dir>
                             </systemProperties>
+                            <serverArgs>
+                                <serverArg>--admin-only</serverArg>
+                            </serverArgs>
                             <scripts>
                                 <script>${project.build.directory}/${wildfly.directory}/bin/adapter-install.cli</script>
                                 <script>src/main/cli/setup-eap.cli</script>

--- a/src/main/cli/adding-redirect.cli
+++ b/src/main/cli/adding-redirect.cli
@@ -1,2 +1,4 @@
 /subsystem=undertow/configuration=handler/file=windup-web-redirect:add(path=${jboss.home.dir}/windup-web-redirect)
 /subsystem=undertow/server=default-server/host=default-host/location=\//:write-attribute(name=handler,value=windup-web-redirect)
+command-timeout set 15000
+reload

--- a/src/main/cli/setup-eap.cli
+++ b/src/main/cli/setup-eap.cli
@@ -36,3 +36,5 @@
 /subsystem=undertow/server=default-server/http-listener=default:write-attribute(name=max-post-size, value=943718400)
 
 /subsystem=transactions:write-attribute(name=node-identifier,value="a")
+command-timeout set 15000
+reload

--- a/src/main/wildfly_overlay/themes/rhamt/login/auto_login.theme.properties
+++ b/src/main/wildfly_overlay/themes/rhamt/login/auto_login.theme.properties
@@ -2,7 +2,7 @@ parent=base
 import=common/keycloak
 
 scripts=js/auto_login.js
-styles=lib/patternfly/css/patternfly.css lib/zocial/zocial.css css/login.css
+styles=node_modules/patternfly/dist/css/patternfly.css node_modules/patternfly/dist/css/patternfly-additions.css lib/zocial/zocial.css css/login.css css/styles.css
 meta=viewport==width=device-width,initial-scale=1
 
 kcHtmlClass=login-pf

--- a/src/main/wildfly_overlay/themes/rhamt/login/login_required.theme.properties
+++ b/src/main/wildfly_overlay/themes/rhamt/login/login_required.theme.properties
@@ -1,7 +1,7 @@
 parent=base
 import=common/keycloak
 
-styles=lib/patternfly/css/patternfly.css lib/zocial/zocial.css css/login.css
+styles=node_modules/patternfly/dist/css/patternfly.css node_modules/patternfly/dist/css/patternfly-additions.css lib/zocial/zocial.css css/login.css css/styles.css
 meta=viewport==width=device-width,initial-scale=1
 
 kcHtmlClass=login-pf


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2507
Changes to use latest Wildfly version, Keycloak
Fixes on wildfly commands due to Wildfly version

Depends on : 
https://github.com/windup/windup-web/pull/625
https://github.com/windup/windup-keycloak-tool/pull/7
https://github.com/windup/windup-web-keycloak-theme/pull/3
