### PR TITLE
Patternfly 4 revamp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
                                     <version>${project.version}</version>
                                     <type>war</type>
                                     <overWrite>true</overWrite>
-                                    <destFileName>mta-web-pf4.war</destFileName>
+                                    <destFileName>mta-ui.war</destFileName>
                                     <outputDirectory>${project.build.directory}/${wildfly.directory}/standalone/deployments/</outputDirectory>
                                 </artifactItem>
                             </artifactItems>

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,15 @@
                                     <destFileName>mta-web.war</destFileName>
                                     <outputDirectory>${project.build.directory}/${wildfly.directory}/standalone/deployments/</outputDirectory>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>windup-web-ui-pf4</artifactId>
+                                    <version>${project.version}</version>
+                                    <type>war</type>
+                                    <overWrite>true</overWrite>
+                                    <destFileName>mta-web-pf4.war</destFileName>
+                                    <outputDirectory>${project.build.directory}/${wildfly.directory}/standalone/deployments/</outputDirectory>
+                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
                                 <artifactItem>
                                     <groupId>org.jboss.windup.web</groupId>
                                     <artifactId>windup-keycloak-tool</artifactId>
-                                    <version>5.4.0-SNAPSHOT</version>
+                                    <version>5.4.0.Final</version>
                                     <outputDirectory>${project.build.directory}/keycloak-tool</outputDirectory>
                                     <destFileName>keycloak-tool.jar</destFileName>
                                     <overWrite>true</overWrite>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
                                 <artifactItem>
                                     <groupId>org.jboss.windup.web</groupId>
                                     <artifactId>windup-keycloak-tool</artifactId>
-                                    <version>5.3.0.Final</version>
+                                    <version>5.4.0-SNAPSHOT</version>
                                     <outputDirectory>${project.build.directory}/keycloak-tool</outputDirectory>
                                     <destFileName>keycloak-tool.jar</destFileName>
                                     <overWrite>true</overWrite>

--- a/src/main/cli/setup-windup-keycloak-properties.cli
+++ b/src/main/cli/setup-windup-keycloak-properties.cli
@@ -1,4 +1,4 @@
 /system-property=keycloak.server.url:add(value="/auth")
 /subsystem=keycloak/secure-deployment=api.war:add(realm=mta, realm-public-key="${keycloak.realm.public.key}", auth-server-url="${keycloak.server.url}", ssl-required="NONE", resource=mta-web, public-client=true)
 /subsystem=keycloak/secure-deployment=mta-web.war:add(realm=mta, realm-public-key="${keycloak.realm.public.key}", auth-server-url="${keycloak.server.url}", ssl-required="NONE", resource=mta-web, public-client=true)
-/subsystem=keycloak/secure-deployment=mta-web-pf4.war:add(realm=mta, realm-public-key="${keycloak.realm.public.key}", auth-server-url="${keycloak.server.url}", ssl-required="NONE", resource=mta-web, public-client=true)
+/subsystem=keycloak/secure-deployment=mta-ui.war:add(realm=mta, realm-public-key="${keycloak.realm.public.key}", auth-server-url="${keycloak.server.url}", ssl-required="NONE", resource=mta-web, public-client=true)

--- a/src/main/cli/setup-windup-keycloak-properties.cli
+++ b/src/main/cli/setup-windup-keycloak-properties.cli
@@ -1,3 +1,4 @@
 /system-property=keycloak.server.url:add(value="/auth")
 /subsystem=keycloak/secure-deployment=api.war:add(realm=mta, realm-public-key="${keycloak.realm.public.key}", auth-server-url="${keycloak.server.url}", ssl-required="NONE", resource=mta-web, public-client=true)
 /subsystem=keycloak/secure-deployment=mta-web.war:add(realm=mta, realm-public-key="${keycloak.realm.public.key}", auth-server-url="${keycloak.server.url}", ssl-required="NONE", resource=mta-web, public-client=true)
+/subsystem=keycloak/secure-deployment=mta-web-pf4.war:add(realm=mta, realm-public-key="${keycloak.realm.public.key}", auth-server-url="${keycloak.server.url}", ssl-required="NONE", resource=mta-web, public-client=true)

--- a/src/main/wildfly_overlay/windup-web-redirect/index.html
+++ b/src/main/wildfly_overlay/windup-web-redirect/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
     <head>
-         <meta http-equiv="refresh" content="0;URL='/mta-web-pf4'">
+         <meta http-equiv="refresh" content="0;URL='/mta-ui'">
     </head>
 </html>

--- a/src/main/wildfly_overlay/windup-web-redirect/index.html
+++ b/src/main/wildfly_overlay/windup-web-redirect/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
 <html>
     <head>
-         <meta http-equiv="refresh" content="0;URL='/mta-web'">
+         <meta http-equiv="refresh" content="0;URL='/mta-web-pf4'">
     </head>
 </html>


### PR DESCRIPTION
Depends on Windup-Web PR: https://github.com/windup/windup-web/pull/658

- Adds `windup-web-ui-pf4` dependency to include the `.war` file which includes the new UI based on Patternfly 4 