### PR TITLE
[WINDUP-3270] - Upgrade MTA Web to use EAP 7.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
                                 <artifactItem>
                                     <groupId>org.jboss.windup.web</groupId>
                                     <artifactId>windup-keycloak-tool</artifactId>
-                                    <version>5.5.0-SNAPSHOT</version>
+                                    <version>5.5.0.Final</version>
                                     <outputDirectory>${project.build.directory}/keycloak-tool</outputDirectory>
                                     <destFileName>keycloak-tool.jar</destFileName>
                                     <overWrite>true</overWrite>

--- a/pom.xml
+++ b/pom.xml
@@ -21,14 +21,14 @@
     <packaging>pom</packaging>
 
     <properties>
-        <version.keycloak>8.0.1</version.keycloak>
+        <version.keycloak>15.1.1</version.keycloak>
 
         <wildfly.groupId>org.wildfly</wildfly.groupId>
         <wildfly.artifactId>wildfly-dist</wildfly.artifactId>
-        <version.wildfly>18.0.1.Final</version.wildfly>
+        <version.wildfly>23.0.2.Final</version.wildfly>
         <wildfly.directory>wildfly-${version.wildfly}</wildfly.directory>
 
-        <version.wildfly.maven.plugin>2.0.2.Final</version.wildfly.maven.plugin>
+        <version.wildfly.maven.plugin>2.1.0.Final</version.wildfly.maven.plugin>
 
         <windup.scm.connection>scm:git:https://github.com/windup/windup-web-distribution.git</windup.scm.connection>
         <windup.developer.connection>scm:git:git@github.com:windup/windup-web-distribution.git</windup.developer.connection>
@@ -104,7 +104,7 @@
                                 <artifactItem>
                                     <groupId>org.jboss.windup.web</groupId>
                                     <artifactId>windup-keycloak-tool</artifactId>
-                                    <version>5.4.0.Final</version>
+                                    <version>5.5.0-SNAPSHOT</version>
                                     <outputDirectory>${project.build.directory}/keycloak-tool</outputDirectory>
                                     <destFileName>keycloak-tool.jar</destFileName>
                                     <overWrite>true</overWrite>

--- a/src/main/cli/setup-eap.cli
+++ b/src/main/cli/setup-eap.cli
@@ -31,6 +31,10 @@
 ## Remove spurious Titan warnings
 /subsystem=logging/logger=com.thinkaurelius.titan.diskstorage.berkeleyje/:add(level=ERROR)
 
+## Tracing
+## The following line removes warning messages from the log due to https://issues.redhat.com/browse/WFLY-14625
+## Which has been fixed in Wildfly 24 but current version for us is 23.0.2
+/subsystem=microprofile-opentracing-smallrye/jaeger-tracer=jaeger:write-attribute(name=sampler-param, value=0)
 
 # Other
 /subsystem=undertow/server=default-server/http-listener=default:write-attribute(name=max-post-size, value=943718400)


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3270

- Upgrade keycloak and wildfly versions
- Deactivated OpenTracing due to log warning messages in the log.