### PR TITLE
Wildfly configured for Windup Web Console development

### DIFF
--- a/.github/workflows/windup-wildfly4development.yml
+++ b/.github/workflows/windup-wildfly4development.yml
@@ -1,0 +1,30 @@
+name: Wildfly for Windup Web Console development
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+
+  windup-wildfly4development:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Windup Web project
+        uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11'
+          cache: 'maven'
+      - name: Package Wildfly for Windup Web Console development
+        run: mvn -s settings.xml clean package -DskipTests -Pwindup-wildfly4development
+      - name: Upload Wildfly for Windup Web Console development
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/windup-wildfly4development.zip
+          overwrite: true
+          tag: windup-wildfly4development

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,8 @@
         <windup.scm.url>http://github.com/windup/windup-web-distribution</windup.scm.url>
 
         <keycloak.tool.path>${project.build.directory}/keycloak-tool/keycloak-tool.jar</keycloak.tool.path>
+        <skip.deployment>false</skip.deployment>
+        <assembly.baseDirectory>${project.build.finalName}</assembly.baseDirectory>
     </properties>
 
     <distributionManagement>
@@ -120,6 +122,7 @@
                             <goal>copy</goal>
                         </goals>
                         <configuration>
+                            <skip>${skip.deployment}</skip>
                             <artifactItems>
                                 <artifactItem>
                                     <groupId>${project.groupId}</groupId>
@@ -472,6 +475,67 @@
                                     </licensesOutputFile>
                                 </configuration>
                             </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>windup-wildfly4development</id>
+            <properties>
+                <skip.deployment>true</skip.deployment>
+                <classifier.wildfly4development>wildfly4development</classifier.wildfly4development>
+                <wildfly4development.name>windup-${classifier.wildfly4development}</wildfly4development.name>
+                <assembly.baseDirectory>${wildfly4development.name}-${project.version}</assembly.baseDirectory>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>distribution</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                                <configuration>
+                                    <finalName>${wildfly4development.name}</finalName>
+                                    <appendAssemblyId>false</appendAssemblyId>
+                                    <attach>true</attach>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-install-plugin</artifactId>
+                        <executions>
+                          <execution>
+                            <id>default-install</id>
+                            <phase>install</phase>
+                            <goals>
+                                <goal>install</goal>
+                            </goals>
+                            <configuration>
+                                <skip>true</skip>
+                            </configuration>
+                          </execution>
+                          <execution>
+                            <id>install-${wildfly4development.name}</id>
+                            <phase>install</phase>
+                            <goals>
+                                <goal>install-file</goal>
+                            </goals>
+                            <configuration>
+                                <file>${project.build.directory}/${wildfly4development.name}.zip</file>
+                                <groupId>${project.groupId}</groupId>
+                                <artifactId>${project.artifactId}</artifactId>
+                                <version>${project.version}</version>
+                                <packaging>zip</packaging>
+                                <classifier>${classifier.wildfly4development}</classifier>
+                            </configuration>
+                          </execution>
                         </executions>
                     </plugin>
                 </plugins>

--- a/src/main/assembly/assembly-offline.xml
+++ b/src/main/assembly/assembly-offline.xml
@@ -6,7 +6,7 @@
         <format>zip</format>
     </formats>
 
-    <baseDirectory>${project.build.finalName}</baseDirectory>
+    <baseDirectory>${assembly.baseDirectory}</baseDirectory>
 
     <!-- Add distribution files -->
     <fileSets>


### PR DESCRIPTION
Nothing changes for standard build.

A new `windup-wildfly4development` Maven profile has been created so that executing `mvn -s settings.xml clean package -DskipTests -Pwindup-wildfly4development` creates locally a preconfigured Wildfly instance to develop Windup Web Console.

A new GH workflow has been added to create a new version of such Wildfly instance for every push to `master` branch (or manually triggered) and upload newly created version to https://github.com/windup/windup-web-distribution/releases/tag/windup-wildfly4development release.