### PR TITLE
Added condition to restrict GH Workflow execution

### DIFF
--- a/.github/workflows/windup-wildfly4development.yml
+++ b/.github/workflows/windup-wildfly4development.yml
@@ -9,6 +9,7 @@ on:
 jobs:
 
   windup-wildfly4development:
+    if: github.repository_owner == 'windup'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Windup Web project


### PR DESCRIPTION
The `windup-wildfly4development` will be executed only on https://github.com/windup/windup-web-distribution/ repository.