### PR TITLE
Avoid the "run" script to fail when parent folder contains spaces

### DIFF
--- a/src/main/resources/run_mta.sh
+++ b/src/main/resources/run_mta.sh
@@ -69,7 +69,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export JBOSS_HOME=$DIR
 
 if [ -z "$WINDUP_DATA_DIR" ] ; then
-    export WINDUP_DATA_DIR=$DIR/standalone/data
+    export WINDUP_DATA_DIR="$DIR/standalone/data"
 fi
 
-$DIR/bin/standalone.sh -c standalone-full.xml -Dwindup.data.dir=$WINDUP_DATA_DIR $@
+"$DIR/bin/standalone.sh" -c standalone-full.xml -Dwindup.data.dir="$WINDUP_DATA_DIR" $@


### PR DESCRIPTION
- When the parent folder where the distribution folder is located contains spaces the "run.sh" execution fails.

This PR avoids the script to fail.