### PR TITLE
Upgrade H2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <version>1.4.194</version>
+            <version>2.1.214</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -190,7 +190,7 @@
                                     <artifactItem>
                                         <groupId>com.h2database</groupId>
                                         <artifactId>h2</artifactId>
-                                        <version>1.4.194</version>
+                                        <version>2.1.214</version>
                                         <outputDirectory>${project.build.directory}/${wildfly.directory}/modules/com/h2database/h2/main</outputDirectory>
                                         <overWrite>true</overWrite>
                                     </artifactItem>

--- a/src/main/cli/setup.cli
+++ b/src/main/cli/setup.cli
@@ -8,7 +8,7 @@
 
 # Properties
 /system-property=windup.data.dir:add(value="${jboss.server.data.dir}/h2/windup-web")
-/subsystem=datasources/data-source=WindupServicesDS:add(jndi-name="java:jboss/datasources/WindupServicesDS", connection-url="jdbc:h2:${windup.data.dir}/h2/windup-web;MULTI_THREADED=1", driver-name="h2", max-pool-size=30, user-name=sa, password=sa)
+/subsystem=datasources/data-source=WindupServicesDS:add(jndi-name="java:jboss/datasources/WindupServicesDS", connection-url="jdbc:h2:${windup.data.dir}/h2/windup-web", driver-name="h2", max-pool-size=30, user-name=sa, password=sa)
 /system-property=windup.data.dir:remove()
 
 # Logging

--- a/src/main/wildfly_overlay/modules/com/h2database/h2/main/module.xml
+++ b/src/main/wildfly_overlay/modules/com/h2database/h2/main/module.xml
@@ -22,18 +22,22 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.3" name="com.h2database.h2">
-    <properties>
-        <property name="jboss.api" value="unsupported"/>
-    </properties>
-
-
+<module xmlns="urn:jboss:module:1.9" name="com.h2database.h2">
     <resources>
-        <resource-root path="h2-1.4.194.jar"/>
+        <resource-root path="h2-2.1.214.jar"/>
     </resources>
     <dependencies>
-        <module name="javax.api"/>
+        <module name="java.compiler"/>
+        <module name="java.desktop"/>
+        <module name="java.instrument"/>
+        <module name="java.logging"/>
+        <module name="java.management"/>
+        <module name="java.naming"/>
+        <module name="java.scripting"/>
+        <module name="java.sql"/>
+        <!--WFLY-14219 Remove deprecated <module name="javax.api"/> -->
         <module name="javax.transaction.api"/>
         <module name="javax.servlet.api" optional="true"/>
+        <module name="org.slf4j"/>
     </dependencies>
 </module>


### PR DESCRIPTION
- MULTI_THREADED removed in h2 v2
- Use default wildfly module.xml skeleton for h2 module

Depends on https://github.com/windup/windup-web/pull/835