### PR TITLE
upgrade keycloak stream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <version.keycloak>18.0.2</version.keycloak>
+        <version.keycloak>22.0.5</version.keycloak>
         <version.windup.web>6.4.0-SNAPSHOT</version.windup.web>
         <version.windup.openshift>6.4.0-SNAPSHOT</version.windup.openshift>
 


### PR DESCRIPTION
Upgrade to latest keycloak,` v22.0.5`

This is to fix https://issues.redhat.com/browse/WINDUP-3772 and WINDUP-3592 in the upstream `windup` artifact, which doesn't have access to an upstream 18.0.9 keycloak version like the downstream supported builds do.