### PR TITLE
WINDUP-4123: upgrade keycloak to v24.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <version.keycloak>22.0.5</version.keycloak>
+        <version.keycloak>22.0.10</version.keycloak>
         <version.windup.web>6.4.0-SNAPSHOT</version.windup.web>
         <version.windup.openshift>6.4.0-SNAPSHOT</version.windup.openshift>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <version.keycloak>22.0.10</version.keycloak>
+        <version.keycloak>24.0.3</version.keycloak>
         <version.windup.web>6.4.0-SNAPSHOT</version.windup.web>
         <version.windup.openshift>6.4.0-SNAPSHOT</version.windup.openshift>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-4123

This PR handles the CVE linked in the JIRA for the upstream windup build ( downstream is taken are of by the pipeline config)