### PR TITLE
[releases/6.3.z] WINDUP-4123: upgrade keycloak to v24.0.3 (#116)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <version.keycloak>22.0.5</version.keycloak>
+        <version.keycloak>24.0.3</version.keycloak>
         <version.windup.web>6.3.8-SNAPSHOT</version.windup.web>
         <version.windup.openshift>6.3.8-SNAPSHOT</version.windup.openshift>
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `master` to `releases/6.3.z`:
 - [WINDUP-4123: upgrade keycloak to v24.0.3 (#116)](https://github.com/windup/windup-web-distribution/pull/116)

<!--- Backport version: 9.5.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)